### PR TITLE
Fix icon loading with invalid resource paths

### DIFF
--- a/Editor/ExtensionMethods/ChiselEditorResources.cs
+++ b/Editor/ExtensionMethods/ChiselEditorResources.cs
@@ -242,7 +242,9 @@ namespace Chisel.Editors
                 if (System.IO.Directory.Exists(packagePath))
                 {
                     var localPath = ToLocalPath(packagePath);
-                    if (foundPaths.Add(localPath)) paths.Add(localPath);
+                    if ((localPath.StartsWith("Assets/") || localPath.StartsWith("Packages/")) &&
+                        foundPaths.Add(localPath))
+                        paths.Add(localPath);
                 }
             }
             return paths.ToArray();


### PR DESCRIPTION
## Summary
- avoid adding absolute paths that Unity cannot load

## Testing
- `npm test` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0f32e1f08330a6fff8bfa634d9ef