### PR TITLE
Add brush debug logging option

### DIFF
--- a/Components/Components/Containers/ChiselModelComponent.cs
+++ b/Components/Components/Containers/ChiselModelComponent.cs
@@ -367,6 +367,8 @@ namespace Chisel.Components
         internal void PrintBrushInfo()
         {
             var brushes = GetComponentsInChildren<ChiselBrushComponent>();
+            var builder = new StringBuilder();
+
             foreach (var brush in brushes)
             {
                 if (!brush || brush.hierarchyItem.Model != this)
@@ -379,27 +381,29 @@ namespace Chisel.Components
                     brushMesh.halfEdges == null)
                     continue;
 
-                var builder = new StringBuilder();
                 builder.AppendLine($"Brush: {brush.name}");
+
                 for (int v = 0; v < brushMesh.vertices.Length; v++)
                     builder.AppendLine($"  v[{v}]: {brushMesh.vertices[v]}");
 
+                int triIndex = 0;
                 for (int p = 0; p < brushMesh.polygons.Length; p++)
                 {
                     ref var poly = ref brushMesh.polygons[p];
-                    builder.Append($"  f[{p}]:");
-                    for (int e = 0; e < poly.edgeCount; e++)
+                    int firstEdge = poly.firstEdge;
+                    var halfEdges = brushMesh.halfEdges;
+                    var v0 = halfEdges[firstEdge].vertexIndex;
+                    for (int i = 1; i < poly.edgeCount - 1; i++)
                     {
-                        var edge = brushMesh.halfEdges[poly.firstEdge + e];
-                        if (e > 0)
-                            builder.Append(',');
-                        builder.Append(edge.vertexIndex);
+                        var v1 = halfEdges[firstEdge + i].vertexIndex;
+                        var v2 = halfEdges[firstEdge + i + 1].vertexIndex;
+                        builder.AppendLine($"  t[{triIndex++}]: {v0}, {v1}, {v2}");
                     }
-                    builder.AppendLine();
                 }
-
-                Debug.Log(builder.ToString(), brush);
             }
+
+            if (builder.Length > 0)
+                Debug.Log(builder.ToString(), this);
         }
 
         void FlipGeneratedMeshes()

--- a/Components/Components/Containers/ChiselModelComponent.cs
+++ b/Components/Components/Containers/ChiselModelComponent.cs
@@ -371,14 +371,19 @@ namespace Chisel.Components
             {
                 if (!brush || brush.hierarchyItem.Model != this)
                     continue;
+
                 var brushMesh = brush.BrushMesh;
-                if (brushMesh == null || brushMesh.vertices == null || brushMesh.polygons == null || brushMesh.halfEdges == null)
+                if (brushMesh == null ||
+                    brushMesh.vertices == null ||
+                    brushMesh.polygons == null ||
+                    brushMesh.halfEdges == null)
                     continue;
 
                 var builder = new StringBuilder();
                 builder.AppendLine($"Brush: {brush.name}");
                 for (int v = 0; v < brushMesh.vertices.Length; v++)
                     builder.AppendLine($"  v[{v}]: {brushMesh.vertices[v]}");
+
                 for (int p = 0; p < brushMesh.polygons.Length; p++)
                 {
                     ref var poly = ref brushMesh.polygons[p];
@@ -386,11 +391,13 @@ namespace Chisel.Components
                     for (int e = 0; e < poly.edgeCount; e++)
                     {
                         var edge = brushMesh.halfEdges[poly.firstEdge + e];
-                        if (e > 0) builder.Append(',');
+                        if (e > 0)
+                            builder.Append(',');
                         builder.Append(edge.vertexIndex);
                     }
                     builder.AppendLine();
                 }
+
                 Debug.Log(builder.ToString(), brush);
             }
         }

--- a/Components/Components/Containers/ChiselModelComponent.cs
+++ b/Components/Components/Containers/ChiselModelComponent.cs
@@ -248,7 +248,6 @@ namespace Chisel.Components
         [NonSerialized]          bool prevSubtractiveEditing;
         [NonSerialized]          bool prevSmoothNormals;
         [NonSerialized]          float prevSmoothingAngle;
-        [NonSerialized]          bool meshUpdateFlag;
 
         
         public ChiselModelComponent() : base() { }
@@ -365,30 +364,7 @@ namespace Chisel.Components
             IsInitialized = true;
         }
 
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-            ChiselModelManager.Instance.PostUpdateModels -= OnPostUpdateModels;
-            ChiselModelManager.Instance.PostUpdateModels += OnPostUpdateModels;
-        }
-
-        protected override void OnDisable()
-        {
-            ChiselModelManager.Instance.PostUpdateModels -= OnPostUpdateModels;
-            base.OnDisable();
-        }
-
-        void OnPostUpdateModels()
-        {
-            if (!meshUpdateFlag)
-                return;
-            meshUpdateFlag = false;
-            if (!DebugLogBrushes)
-                return;
-            PrintBrushInfo();
-        }
-
-        void PrintBrushInfo()
+        internal void PrintBrushInfo()
         {
             var brushes = GetComponentsInChildren<ChiselBrushComponent>();
             foreach (var brush in brushes)

--- a/Components/Components/Generated/ChiselGeneratedObjects.cs
+++ b/Components/Components/Generated/ChiselGeneratedObjects.cs
@@ -674,10 +674,12 @@ namespace Chisel.Components
 
                 var foundMeshCount = foundMeshes.Count;
                 foundMeshes.Clear();
+                if (model.DebugLogBrushes)
+                    model.PrintBrushInfo();
                 return foundMeshCount;
             }
             finally
-			{
+                        {
 				DictionaryPool<ChiselModelComponent, GameObjectState>.Release(gameObjectStates);
 				ListPool<ChiselMeshUpdate>.Release(renderMeshUpdates);
 				//ListPool<ChiselColliderObjectUpdate>.Release(colliderObjectUpdates);

--- a/Components/Managers/ChiselModelManager.cs
+++ b/Components/Managers/ChiselModelManager.cs
@@ -82,9 +82,9 @@ namespace Chisel.Components
 			}
 
                         var count = foundModel.generated.FinishMeshUpdates(foundModel, meshUpdates, dependencies);
-                        Instance.Rebuild(foundModel);
                         if (foundModel.DebugLogBrushes)
                                 foundModel.PrintBrushInfo();
+                        Instance.Rebuild(foundModel);
                         return count;
                 }
 

--- a/Components/Managers/ChiselModelManager.cs
+++ b/Components/Managers/ChiselModelManager.cs
@@ -82,8 +82,9 @@ namespace Chisel.Components
 			}
 
                         var count = foundModel.generated.FinishMeshUpdates(foundModel, meshUpdates, dependencies);
-                        foundModel.meshUpdateFlag = true;
                         Instance.Rebuild(foundModel);
+                        if (foundModel.DebugLogBrushes)
+                                foundModel.PrintBrushInfo();
                         return count;
                 }
 

--- a/Components/Managers/ChiselModelManager.cs
+++ b/Components/Managers/ChiselModelManager.cs
@@ -81,10 +81,11 @@ namespace Chisel.Components
 				foundModel.generated = ChiselGeneratedObjects.Create(foundModel.gameObject);
 			}
 
-			var count = foundModel.generated.FinishMeshUpdates(foundModel, meshUpdates, dependencies);
-			Instance.Rebuild(foundModel);
-			return count;
-		}
+                        var count = foundModel.generated.FinishMeshUpdates(foundModel, meshUpdates, dependencies);
+                        foundModel.meshUpdateFlag = true;
+                        Instance.Rebuild(foundModel);
+                        return count;
+                }
 
 		readonly static FinishMeshUpdate finishMeshUpdatesMethod = (FinishMeshUpdate)FinishMeshUpdates;
 

--- a/Components/Managers/ChiselModelManager.cs
+++ b/Components/Managers/ChiselModelManager.cs
@@ -82,8 +82,6 @@ namespace Chisel.Components
 			}
 
                         var count = foundModel.generated.FinishMeshUpdates(foundModel, meshUpdates, dependencies);
-                        if (foundModel.DebugLogBrushes)
-                                foundModel.PrintBrushInfo();
                         Instance.Rebuild(foundModel);
                         return count;
                 }

--- a/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -47,6 +47,7 @@ namespace Chisel.Editors
         readonly static GUIContent kLightingContent                        = new("Lighting");
         readonly static GUIContent kProbesContent                          = new("Probes");
         readonly static GUIContent kAdditionalSettingsContent              = new("Additional Settings");
+        readonly static GUIContent kDebugContent                          = new("Debug");
         readonly static GUIContent kGenerationSettingsContent              = new("Geometry Output");
         readonly static GUIContent kColliderSettingsContent                = new("Collider");
         readonly static GUIContent kCreateRenderComponentsContents         = new("Renderable");
@@ -54,6 +55,7 @@ namespace Chisel.Editors
         readonly static GUIContent kSubtractiveEditingContents            = new("Subtractive Editing", "New brushes are created as subtractive when enabled");
         readonly static GUIContent kSmoothNormalsContents                 = new("Smooth Normals");
         readonly static GUIContent kSmoothingAngleContents                = new("Smoothing Angle");
+        readonly static GUIContent kDebugLogBrushesContents               = new("Log Brushes");
         readonly static GUIContent kUnwrapParamsContents                   = new("UV Generation");
 
         readonly static GUIContent kForceBuildUVsContents                  = new("Build", "Manually build lightmap UVs for generated meshes. This operation can be slow for more complicated meshes");
@@ -126,6 +128,7 @@ namespace Chisel.Editors
         const string kDisplayLightmapKey            = "ChiselModelEditor.ShowLightmapSettings";
         const string kDisplayChartingKey            = "ChiselModelEditor.ShowChartingSettings";
         const string kDisplayUnwrapParamsKey        = "ChiselModelEditor.ShowUnwrapParams";
+        const string kDisplayDebugKey               = "ChiselModelEditor.ShowDebug";
 
 
         SerializedProperty vertexChannelMaskProp;
@@ -156,6 +159,7 @@ namespace Chisel.Editors
         SerializedProperty lightProbeVolumeOverrideProp;
         SerializedProperty probeAnchorProp;
         SerializedProperty stitchLightmapSeamsProp;
+        SerializedProperty debugLogBrushesProp;
 
         SerializedObject   gameObjectsSerializedObject;
         SerializedProperty staticEditorFlagsProp;
@@ -174,6 +178,7 @@ namespace Chisel.Editors
         bool showLightmapSettings;
         bool showChartingSettings;
         bool showUnwrapParams;
+        bool showDebug;
 
         UnityEngine.Object[] childNodes;
 
@@ -213,6 +218,7 @@ namespace Chisel.Editors
             showLightmapSettings    = SessionState.GetBool(kDisplayLightmapKey, true);
             showChartingSettings    = SessionState.GetBool(kDisplayChartingKey, true);
             showUnwrapParams        = SessionState.GetBool(kDisplayUnwrapParamsKey, true);
+            showDebug               = EditorPrefs.GetBool(kDisplayDebugKey, false);
 
             if (!target)
             {
@@ -250,6 +256,7 @@ namespace Chisel.Editors
             lightProbeVolumeOverrideProp        = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kLightProbeVolumeOverrideName}");
             probeAnchorProp                     = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kProbeAnchorName}");
             stitchLightmapSeamsProp             = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kStitchLightmapSeamsName}");
+            debugLogBrushesProp                 = serializedObject.FindProperty($"{ChiselModelComponent.kDebugLogBrushesName}");
 
             convexProp              = serializedObject.FindProperty($"{ChiselModelComponent.kColliderSettingsName}.{ChiselGeneratedColliderSettings.kConvexName}");
             isTriggerProp           = serializedObject.FindProperty($"{ChiselModelComponent.kColliderSettingsName}.{ChiselGeneratedColliderSettings.kIsTriggerName}");
@@ -1193,6 +1200,7 @@ namespace Chisel.Editors
             
                 var oldShowGenerationSettings   = showGenerationSettings;
                 var oldShowColliderSettings     = showColliderSettings;
+                var oldShowDebug                = showDebug;
 
                 if (gameObjectsSerializedObject != null) gameObjectsSerializedObject.Update();
                 if (serializedObject != null) serializedObject.Update();
@@ -1252,6 +1260,15 @@ namespace Chisel.Editors
                         }
                         EditorGUILayout.EndFoldoutHeaderGroup();
                     }
+
+                    showDebug = EditorGUILayout.BeginFoldoutHeaderGroup(showDebug, kDebugContent);
+                    if (showDebug)
+                    {
+                        EditorGUI.indentLevel++;
+                        EditorGUILayout.PropertyField(debugLogBrushesProp, kDebugLogBrushesContents);
+                        EditorGUI.indentLevel--;
+                    }
+                    EditorGUILayout.EndFoldoutHeaderGroup();
                 }
                 if (EditorGUI.EndChangeCheck())
                 {
@@ -1264,6 +1281,7 @@ namespace Chisel.Editors
             
                 if (showGenerationSettings  != oldShowGenerationSettings) SessionState.SetBool(kDisplayGenerationSettingsKey, showGenerationSettings);
                 if (showColliderSettings    != oldShowColliderSettings  ) SessionState.SetBool(kDisplayColliderSettingsKey, showColliderSettings);
+                if (showDebug              != oldShowDebug           ) EditorPrefs.SetBool(kDisplayDebugKey, showDebug);
             }
             finally
             { 


### PR DESCRIPTION
## Summary
- add a `DebugLogBrushes` option to `ChiselModelComponent`
- print brush vertices and faces when meshes are regenerated

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cfdb953908330b0ffa7ba8fcc4b71