### PR TITLE
Add debug brush logging

### DIFF
--- a/Components/Components/Containers/ChiselModelComponent.cs
+++ b/Components/Components/Containers/ChiselModelComponent.cs
@@ -212,6 +212,7 @@ namespace Chisel.Components
         public const string kSubtractiveEditingName       = nameof(SubtractiveEditing);
         public const string kSmoothNormalsName            = nameof(SmoothNormals);
         public const string kSmoothingAngleName           = nameof(SmoothingAngle);
+        public const string kDebugLogBrushesName          = nameof(DebugLogBrushes);
 
 
         public const string kNodeTypeName = "Model";

--- a/Components/Components/Containers/ChiselModelComponent.cs
+++ b/Components/Components/Containers/ChiselModelComponent.cs
@@ -246,6 +246,12 @@ namespace Chisel.Components
         [NonSerialized]          bool prevSmoothNormals;
         [NonSerialized]          float prevSmoothingAngle;
 
+        #region Debug
+        // When enabled all brush geometry will be printed out to the console
+        // at the start of the CSG job update
+        public bool DebugLogBrushes = false;
+        #endregion
+
         
         public ChiselModelComponent() : base() { }
 

--- a/Core/2.Processing/Managers/CSGManager.UpdateTreeMeshes.cs
+++ b/Core/2.Processing/Managers/CSGManager.UpdateTreeMeshes.cs
@@ -876,11 +876,11 @@ namespace Chisel.Core
                         var brushMeshBlob = BrushMeshManager.GetBrushMeshBlob(brush.BrushMesh);
                         if (!brushMeshBlob.IsCreated)
                             continue;
-                        var vertices = brushMeshBlob.Value.localVertices;
+                        ref var vertices = ref brushMeshBlob.Value.localVertices;
                         for (int v = 0; v < vertices.Length; v++)
                             sb.AppendLine($"  v{v}: {vertices[v]}");
-                        var halfEdges = brushMeshBlob.Value.halfEdges;
-                        var polygons = brushMeshBlob.Value.polygons;
+                        ref var halfEdges = ref brushMeshBlob.Value.halfEdges;
+                        ref var polygons = ref brushMeshBlob.Value.polygons;
                         for (int p = 0; p < polygons.Length; p++)
                         {
                             var polygon = polygons[p];

--- a/Core/2.Processing/Managers/CSGManager.UpdateTreeMeshes.cs
+++ b/Core/2.Processing/Managers/CSGManager.UpdateTreeMeshes.cs
@@ -6,6 +6,7 @@ using Unity.Profiling;
 using Unity.Entities;
 using System.Buffers;
 using UnityEngine;
+using System.Reflection;
 
 namespace Chisel.Core
 {
@@ -636,41 +637,6 @@ namespace Chisel.Core
 				var chiselLookupValues = ChiselTreeLookup.Value[this.tree];
                 ref var brushMeshBlobs = ref ChiselMeshLookup.Value.brushMeshBlobCache;
 
-                var model = UnityEngine.Resources.InstanceIDToObject(this.tree.InstanceID) as Chisel.Components.ChiselModelComponent;
-                if (model != null && model.DebugLogBrushes)
-                {
-                    var sb = new System.Text.StringBuilder();
-                    sb.AppendLine("Brush Debug Info:");
-                    for (int i = 0; i < Temporaries.brushes.Length; i++)
-                    {
-                        var brushID = Temporaries.brushes[i];
-                        var brush = CSGTreeBrush.FindNoErrors(brushID);
-                        if (!brush.Valid)
-                            continue;
-                        sb.AppendLine($"Brush {i} Operation: {brush.Operation}");
-                        var brushMeshBlob = BrushMeshManager.GetBrushMeshBlob(brush.BrushMesh);
-                        if (!brushMeshBlob.IsCreated)
-                            continue;
-                        var vertices = brushMeshBlob.Value.localVertices;
-                        for (int v = 0; v < vertices.Length; v++)
-                            sb.AppendLine($"  v{v}: {vertices[v]}");
-                        var halfEdges = brushMeshBlob.Value.halfEdges;
-                        var polygons = brushMeshBlob.Value.polygons;
-                        for (int p = 0; p < polygons.Length; p++)
-                        {
-                            var polygon = polygons[p];
-                            sb.Append($"  f{p}:");
-                            for (int e = 0; e < polygon.edgeCount; e++)
-                            {
-                                var edgeIndex = polygon.firstEdge + e;
-                                sb.Append(' ');
-                                sb.Append(halfEdges[edgeIndex].vertexIndex);
-                            }
-                            sb.AppendLine();
-                        }
-                    }
-                    UnityEngine.Debug.Log(sb.ToString());
-                }
                 {
                     #region Build Lookup Tables
                     using (kJobBuildLookupTablesJobProfilerMarker.Auto())
@@ -876,9 +842,60 @@ namespace Chisel.Core
             }
 
             public void RunMeshUpdateJobs()
-			{
-				var chiselLookupValues = ChiselTreeLookup.Value[this.tree];
+                        {
+                                var chiselLookupValues = ChiselTreeLookup.Value[this.tree];
                 ref var brushMeshBlobs = ref ChiselMeshLookup.Value.brushMeshBlobCache;
+
+                // Debug logging of all brush geometry when enabled on the model
+                var modelObj = UnityEngine.Resources.InstanceIDToObject(this.tree.InstanceID);
+                bool debugLogBrushes = false;
+                if (modelObj != null)
+                {
+                    var type = modelObj.GetType();
+                    var prop = type.GetProperty("DebugLogBrushes", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                    if (prop != null && prop.PropertyType == typeof(bool))
+                        debugLogBrushes = (bool)prop.GetValue(modelObj);
+                    else
+                    {
+                        var field = type.GetField("DebugLogBrushes", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                        if (field != null && field.FieldType == typeof(bool))
+                            debugLogBrushes = (bool)field.GetValue(modelObj);
+                    }
+                }
+                if (debugLogBrushes)
+                {
+                    var sb = new System.Text.StringBuilder();
+                    sb.AppendLine("Brush Debug Info:");
+                    for (int i = 0; i < Temporaries.brushes.Length; i++)
+                    {
+                        var brushID = Temporaries.brushes[i];
+                        var brush = CSGTreeBrush.FindNoErrors(brushID);
+                        if (!brush.Valid)
+                            continue;
+                        sb.AppendLine($"Brush {i} Operation: {brush.Operation}");
+                        var brushMeshBlob = BrushMeshManager.GetBrushMeshBlob(brush.BrushMesh);
+                        if (!brushMeshBlob.IsCreated)
+                            continue;
+                        var vertices = brushMeshBlob.Value.localVertices;
+                        for (int v = 0; v < vertices.Length; v++)
+                            sb.AppendLine($"  v{v}: {vertices[v]}");
+                        var halfEdges = brushMeshBlob.Value.halfEdges;
+                        var polygons = brushMeshBlob.Value.polygons;
+                        for (int p = 0; p < polygons.Length; p++)
+                        {
+                            var polygon = polygons[p];
+                            sb.Append($"  f{p}:");
+                            for (int e = 0; e < polygon.edgeCount; e++)
+                            {
+                                var edgeIndex = polygon.firstEdge + e;
+                                sb.Append(' ');
+                                sb.Append(halfEdges[edgeIndex].vertexIndex);
+                            }
+                            sb.AppendLine();
+                        }
+                    }
+                    UnityEngine.Debug.Log(sb.ToString());
+                }
 
                 #region Perform CSG
 

--- a/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -54,6 +54,7 @@ namespace Chisel.Editors
         readonly static GUIContent kSubtractiveEditingContents            = new("Subtractive Editing", "New brushes are created as subtractive when enabled");
         readonly static GUIContent kSmoothNormalsContents                 = new("Smooth Normals");
         readonly static GUIContent kSmoothingAngleContents                = new("Smoothing Angle");
+        readonly static GUIContent kDebugLogBrushesContents              = new("Debug Log Brushes");
         readonly static GUIContent kUnwrapParamsContents                   = new("UV Generation");
 
         readonly static GUIContent kForceBuildUVsContents                  = new("Build", "Manually build lightmap UVs for generated meshes. This operation can be slow for more complicated meshes");
@@ -134,6 +135,7 @@ namespace Chisel.Editors
         SerializedProperty subtractiveEditingProp;
         SerializedProperty smoothNormalsProp;
         SerializedProperty smoothingAngleProp;
+        SerializedProperty debugLogBrushesProp;
         SerializedProperty autoRebuildUVsProp;
         SerializedProperty angleErrorProp;
         SerializedProperty areaErrorProp;
@@ -226,6 +228,7 @@ namespace Chisel.Editors
            subtractiveEditingProp       = serializedObject.FindProperty($"{ChiselModelComponent.kSubtractiveEditingName}");
             smoothNormalsProp           = serializedObject.FindProperty($"{ChiselModelComponent.kSmoothNormalsName}");
             smoothingAngleProp          = serializedObject.FindProperty($"{ChiselModelComponent.kSmoothingAngleName}");
+            debugLogBrushesProp         = serializedObject.FindProperty($"{ChiselModelComponent.kDebugLogBrushesName}");
            autoRebuildUVsProp           = serializedObject.FindProperty($"{ChiselModelComponent.kAutoRebuildUVsName}");
             angleErrorProp               = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kUVGenerationSettingsName}.{SerializableUnwrapParam.kAngleErrorName}");
             areaErrorProp                = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kUVGenerationSettingsName}.{SerializableUnwrapParam.kAreaErrorName}");
@@ -1219,6 +1222,7 @@ namespace Chisel.Editors
                         EditorGUILayout.PropertyField(smoothNormalsProp, kSmoothNormalsContents);
                         if (smoothNormalsProp.boolValue)
                             EditorGUILayout.PropertyField(smoothingAngleProp, kSmoothingAngleContents);
+                        EditorGUILayout.PropertyField(debugLogBrushesProp, kDebugLogBrushesContents);
 
                         EditorGUI.BeginDisabledGroup(!createRenderComponentsProp.boolValue);
                         {

--- a/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -49,6 +49,7 @@ namespace Chisel.Editors
         readonly static GUIContent kAdditionalSettingsContent              = new("Additional Settings");
         readonly static GUIContent kGenerationSettingsContent              = new("Geometry Output");
         readonly static GUIContent kColliderSettingsContent                = new("Collider");
+        readonly static GUIContent kDebugContent                           = new("Debug");
         readonly static GUIContent kCreateRenderComponentsContents         = new("Renderable");
         readonly static GUIContent kCreateColliderComponentsContents       = new("Collidable");
         readonly static GUIContent kSubtractiveEditingContents            = new("Subtractive Editing", "New brushes are created as subtractive when enabled");
@@ -127,6 +128,7 @@ namespace Chisel.Editors
         const string kDisplayLightmapKey            = "ChiselModelEditor.ShowLightmapSettings";
         const string kDisplayChartingKey            = "ChiselModelEditor.ShowChartingSettings";
         const string kDisplayUnwrapParamsKey        = "ChiselModelEditor.ShowUnwrapParams";
+        const string kDisplayDebugKey               = "ChiselModelEditor.ShowDebugSettings";
 
 
         SerializedProperty vertexChannelMaskProp;
@@ -176,6 +178,7 @@ namespace Chisel.Editors
         bool showLightmapSettings;
         bool showChartingSettings;
         bool showUnwrapParams;
+        bool showDebug;
 
         UnityEngine.Object[] childNodes;
 
@@ -215,6 +218,7 @@ namespace Chisel.Editors
             showLightmapSettings    = SessionState.GetBool(kDisplayLightmapKey, true);
             showChartingSettings    = SessionState.GetBool(kDisplayChartingKey, true);
             showUnwrapParams        = SessionState.GetBool(kDisplayUnwrapParamsKey, true);
+            showDebug               = SessionState.GetBool(kDisplayDebugKey, false);
 
             if (!target)
             {
@@ -1196,6 +1200,7 @@ namespace Chisel.Editors
             
                 var oldShowGenerationSettings   = showGenerationSettings;
                 var oldShowColliderSettings     = showColliderSettings;
+                var oldShowDebug                = showDebug;
 
                 if (gameObjectsSerializedObject != null) gameObjectsSerializedObject.Update();
                 if (serializedObject != null) serializedObject.Update();
@@ -1222,7 +1227,6 @@ namespace Chisel.Editors
                         EditorGUILayout.PropertyField(smoothNormalsProp, kSmoothNormalsContents);
                         if (smoothNormalsProp.boolValue)
                             EditorGUILayout.PropertyField(smoothingAngleProp, kSmoothingAngleContents);
-                        EditorGUILayout.PropertyField(debugLogBrushesProp, kDebugLogBrushesContents);
 
                         EditorGUI.BeginDisabledGroup(!createRenderComponentsProp.boolValue);
                         {
@@ -1256,6 +1260,15 @@ namespace Chisel.Editors
                         }
                         EditorGUILayout.EndFoldoutHeaderGroup();
                     }
+
+                    showDebug = EditorGUILayout.BeginFoldoutHeaderGroup(showDebug, kDebugContent);
+                    if (showDebug)
+                    {
+                        EditorGUI.indentLevel++;
+                        EditorGUILayout.PropertyField(debugLogBrushesProp, kDebugLogBrushesContents);
+                        EditorGUI.indentLevel--;
+                    }
+                    EditorGUILayout.EndFoldoutHeaderGroup();
                 }
                 if (EditorGUI.EndChangeCheck())
                 {
@@ -1268,6 +1281,7 @@ namespace Chisel.Editors
             
                 if (showGenerationSettings  != oldShowGenerationSettings) SessionState.SetBool(kDisplayGenerationSettingsKey, showGenerationSettings);
                 if (showColliderSettings    != oldShowColliderSettings  ) SessionState.SetBool(kDisplayColliderSettingsKey, showColliderSettings);
+                if (showDebug               != oldShowDebug           ) SessionState.SetBool(kDisplayDebugKey, showDebug);
             }
             finally
             { 


### PR DESCRIPTION
## Summary
- add `DebugLogBrushes` option on `ChiselModelComponent`
- log brush vertices and faces when `DebugLogBrushes` is enabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d34138ba88330a16c907613c3ed0a