### PR TITLE
Add DebugLogOutput option

### DIFF
--- a/Components/Components/Containers/ChiselModelComponent.cs
+++ b/Components/Components/Containers/ChiselModelComponent.cs
@@ -213,6 +213,7 @@ namespace Chisel.Components
         public const string kSmoothNormalsName            = nameof(SmoothNormals);
         public const string kSmoothingAngleName           = nameof(SmoothingAngle);
         public const string kDebugLogBrushesName          = nameof(DebugLogBrushes);
+        public const string kDebugLogOutputName           = nameof(DebugLogOutput);
 
 
         public const string kNodeTypeName = "Model";
@@ -251,6 +252,8 @@ namespace Chisel.Components
         // When enabled all brush geometry will be printed out to the console
         // at the start of the CSG job update
         public bool DebugLogBrushes = false;
+        // When enabled the generated output mesh data will be printed out after rebuilding
+        public bool DebugLogOutput = false;
         #endregion
 
         

--- a/Components/Components/Generated/ChiselGeneratedObjects.cs
+++ b/Components/Components/Generated/ChiselGeneratedObjects.cs
@@ -5,6 +5,7 @@ using UnityEngine.Rendering;
 using UnityEngine.Profiling;
 using Unity.Jobs;
 using UnityEngine.Pool;
+using System.Text;
 
 namespace Chisel.Components
 {        
@@ -671,6 +672,24 @@ namespace Chisel.Components
                 colliderDebugVisualization.sharedMesh.CombineMeshes(colliderMeshes);
                 colliderDebugVisualization.renderMaterials = new Material[] { ChiselProjectSettings.CollisionSurfacesMaterial };
                 // }}
+
+                if (model.DebugLogOutput)
+                {
+                    var sb = new System.Text.StringBuilder();
+                    sb.AppendLine("Output Mesh Debug Info:");
+                    for (int m = 0; m < foundMeshes.Count; m++)
+                    {
+                        var mesh = foundMeshes[m];
+                        sb.AppendLine($"Mesh {m} vertices:");
+                        var verts = mesh.vertices;
+                        for (int v = 0; v < verts.Length; v++)
+                            sb.AppendLine($"  v{v}: {verts[v]}");
+                        var tris = mesh.triangles;
+                        for (int t = 0; t < tris.Length; t += 3)
+                            sb.AppendLine($"  t{t / 3}: {tris[t]}, {tris[t + 1]}, {tris[t + 2]}");
+                    }
+                    UnityEngine.Debug.Log(sb.ToString());
+                }
 
                 var foundMeshCount = foundMeshes.Count;
                 foundMeshes.Clear();

--- a/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
+++ b/Editor/ComponentEditors/Containers/ChiselModelEditor.cs
@@ -56,6 +56,7 @@ namespace Chisel.Editors
         readonly static GUIContent kSmoothNormalsContents                 = new("Smooth Normals");
         readonly static GUIContent kSmoothingAngleContents                = new("Smoothing Angle");
         readonly static GUIContent kDebugLogBrushesContents              = new("Debug Log Brushes");
+        readonly static GUIContent kDebugLogOutputContents               = new("Debug Log Output");
         readonly static GUIContent kUnwrapParamsContents                   = new("UV Generation");
 
         readonly static GUIContent kForceBuildUVsContents                  = new("Build", "Manually build lightmap UVs for generated meshes. This operation can be slow for more complicated meshes");
@@ -138,6 +139,7 @@ namespace Chisel.Editors
         SerializedProperty smoothNormalsProp;
         SerializedProperty smoothingAngleProp;
         SerializedProperty debugLogBrushesProp;
+        SerializedProperty debugLogOutputProp;
         SerializedProperty autoRebuildUVsProp;
         SerializedProperty angleErrorProp;
         SerializedProperty areaErrorProp;
@@ -233,6 +235,7 @@ namespace Chisel.Editors
             smoothNormalsProp           = serializedObject.FindProperty($"{ChiselModelComponent.kSmoothNormalsName}");
             smoothingAngleProp          = serializedObject.FindProperty($"{ChiselModelComponent.kSmoothingAngleName}");
             debugLogBrushesProp         = serializedObject.FindProperty($"{ChiselModelComponent.kDebugLogBrushesName}");
+            debugLogOutputProp          = serializedObject.FindProperty($"{ChiselModelComponent.kDebugLogOutputName}");
            autoRebuildUVsProp           = serializedObject.FindProperty($"{ChiselModelComponent.kAutoRebuildUVsName}");
             angleErrorProp               = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kUVGenerationSettingsName}.{SerializableUnwrapParam.kAngleErrorName}");
             areaErrorProp                = serializedObject.FindProperty($"{ChiselModelComponent.kRenderSettingsName}.{ChiselGeneratedRenderSettings.kUVGenerationSettingsName}.{SerializableUnwrapParam.kAreaErrorName}");
@@ -1266,6 +1269,7 @@ namespace Chisel.Editors
                     {
                         EditorGUI.indentLevel++;
                         EditorGUILayout.PropertyField(debugLogBrushesProp, kDebugLogBrushesContents);
+                        EditorGUILayout.PropertyField(debugLogOutputProp, kDebugLogOutputContents);
                         EditorGUI.indentLevel--;
                     }
                     EditorGUILayout.EndFoldoutHeaderGroup();


### PR DESCRIPTION
## Summary
- add new `DebugLogOutput` flag on `ChiselModelComponent`
- expose `DebugLogOutput` checkbox in `ChiselModelEditor`
- when enabled, log vertices and triangles of generated meshes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dfa82c1208330bd04bd721277386c