### PR TITLE
Add orientation fallback for triangulation

### DIFF
--- a/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
+++ b/Core/2.Processing/Jobs/GenerateSurfaceTrianglesJob.cs
@@ -256,32 +256,57 @@ namespace Chisel.Core
 							if (IsDegenerate(roVerts.positions2D))
 								continue;
 
-							try
-							{
-								output.Triangles.Clear();
-								triangulator.Triangulate(
-									new andywiecko.BurstTriangulator.LowLevel.Unsafe.InputData<double2>
-									{
-										Positions = roVerts.positions2D,
-										ConstraintEdges = roVerts.edgeIndices
-									},
-									output,
-									settings,
-									Allocator.Temp);
+                                                        try
+                                                        {
+                                                                output.Triangles.Clear();
+                                                                triangulator.Triangulate(
+                                                                        new andywiecko.BurstTriangulator.LowLevel.Unsafe.InputData<double2>
+                                                                        {
+                                                                               Positions = roVerts.positions2D,
+                                                                               ConstraintEdges = roVerts.edgeIndices
+                                                                        },
+                                                                        output,
+                                                                        settings,
+                                                                        Allocator.Temp);
+
+                                                                if (output.Status.Value != Status.OK || output.Triangles.Length == 0)
+                                                                {
+                                                                        var area = ComputeSignedArea(roVerts.positions2D, roVerts.edgeIndices);
+                                                                        if (area < 0)
+                                                                        {
+                                                                                for (int ri = 0; ri < vertex2DRemapper.edgeIndices.Length; ri += 2)
+                                                                                {
+                                                                                        var tmp = vertex2DRemapper.edgeIndices[ri];
+                                                                                        vertex2DRemapper.edgeIndices[ri] = vertex2DRemapper.edgeIndices[ri + 1];
+                                                                                        vertex2DRemapper.edgeIndices[ri + 1] = tmp;
+                                                                                }
+                                                                                roVerts = vertex2DRemapper.AsReadOnly();
+                                                                                output.Triangles.Clear();
+                                                                                triangulator.Triangulate(
+                                                                                        new andywiecko.BurstTriangulator.LowLevel.Unsafe.InputData<double2>
+                                                                                        {
+                                                                                                Positions = roVerts.positions2D,
+                                                                                                ConstraintEdges = roVerts.edgeIndices
+                                                                                        },
+                                                                                        output,
+                                                                                        settings,
+                                                                                        Allocator.Temp);
+                                                                        }
+                                                                }
 #if UNITY_EDITOR && DEBUG
-								// Inside the loop after calling Triangulate:
-								if (output.Status.Value != Status.OK)
-								{
-									// Log the specific status enum value/name for more detail!
-									Debug.LogError($"Triangulator failed for surface {surf}, loop index {loopIdx} with status {output.Status.Value.ToString()} ({output.Status.Value})");
-								}
-								else if (output.Triangles.Length == 0)
-								{
-									Debug.LogError($"Triangulator returned zero triangles for surface {surf}, loop index {loopIdx}.");
-								}
+                                                                // Inside the loop after calling Triangulate:
+                                                                if (output.Status.Value != Status.OK)
+                                                                {
+                                                                        // Log the specific status enum value/name for more detail!
+                                                                        Debug.LogError($"Triangulator failed for surface {surf}, loop index {loopIdx} with status {output.Status.Value.ToString()} ({output.Status.Value})");
+                                                                }
+                                                                else if (output.Triangles.Length == 0)
+                                                                {
+                                                                        Debug.LogError($"Triangulator returned zero triangles for surface {surf}, loop index {loopIdx}.");
+                                                                }
 #endif
-								if (output.Status.Value != Status.OK || output.Triangles.Length == 0)
-									continue;
+                                                                if (output.Status.Value != Status.OK || output.Triangles.Length == 0)
+                                                                        continue;
 
 								// Map triangles back
 								var prevCount = surfaceIndexList.Length;
@@ -388,10 +413,10 @@ namespace Chisel.Core
 				}
 			}
 		}
-		static bool IsDegenerate(NativeArray<double2> verts)
-		{
-			if (verts.Length < 3)
-				return true;
+                static bool IsDegenerate(NativeArray<double2> verts)
+                {
+                        if (verts.Length < 3)
+                                return true;
 
 			double2 min = verts[0];
 			double2 max = verts[0];
@@ -405,7 +430,19 @@ namespace Chisel.Core
 
 			// A zero-area axis-aligned box means every point sits on a line
 			return math.abs(max.x - min.x) <= double.Epsilon ||
-				   math.abs(max.y - min.y) <= double.Epsilon;
-		}
-	}
+                                   math.abs(max.y - min.y) <= double.Epsilon;
+                }
+
+                static double ComputeSignedArea(NativeArray<double2> verts, NativeArray<int> edges)
+                {
+                        double area = 0;
+                        for (int i = 0; i < edges.Length; i += 2)
+                        {
+                                var a = verts[edges[i]];
+                                var b = verts[edges[i + 1]];
+                                area += (a.x * b.y) - (b.x * a.y);
+                        }
+                        return area * 0.5;
+                }
+        }
 }

--- a/Package Resources/Materials/URP/Defaults/Wall.mat
+++ b/Package Resources/Materials/URP/Defaults/Wall.mat
@@ -49,7 +49,8 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Opaque
-  disabledShaderPasses: []
+  disabledShaderPasses:
+  - MOTIONVECTORS
   m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
@@ -155,6 +156,7 @@ Material:
     - _Surface: 0
     - _UVSec: 0
     - _WorkflowMode: 1
+    - _XRMotionVectorsPass: 1
     - _ZWrite: 1
     m_Colors:
     - <noninit>: {r: 1, g: 1, b: 1, a: 1}

--- a/Package Resources/Materials/builtin/Defaults/Wall.mat
+++ b/Package Resources/Materials/builtin/Defaults/Wall.mat
@@ -147,3 +147,16 @@ Material:
     - _SpecColor: {r: 0.09433961, g: 0.09433961, b: 0.09433961, a: 1}
   m_BuildTextureStacks: []
   m_AllowLocking: 1
+--- !u!114 &598466056720961285
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 10


### PR DESCRIPTION
## Summary
- add orientation-aware fallback when triangulator fails
- utility to compute polygon area for determining orientation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e033ac1108330ae1b9ee7f74717a9